### PR TITLE
lock timechart behind feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Breaking Changes & Fixes
+
+### 0.3.0 -> 0.4.0
+
+ * `XyTimeData` and `TimeData` are now locked behind the feature `timechart`.
+    * Specify feature `timechart` when including in your Cargo.toml to use these built in charts.
+ * `Chart` type now generic and mutable
+    * Specify chart data type when initializing, or if it has none create a `Chart::<()>::new()`
+    * Accessing the chart's data no longer requires a `.downcast` and is directly accessable
+
 ## 0.3.0
 
  * Added premade charts

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,23 @@ exclude = [
     "images"
 ]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+timechart = ["dep:instant"]
 
 [dependencies]
-egui = "0.22.0" 
-plotters-backend = "0.3.4"
-plotters = "0.3.1"
+egui = "0.22" 
+plotters-backend = "0.3"
+plotters = "0.3"
+# if you are using egui then chances are you're using trunk which uses wasm bindgen
+instant = { version = "0.1", features = ["wasm-bindgen"], optional = true }
 
 [dev-dependencies]
 eframe = "0.22.0"
 
+[[example]]
+name = "spiral"
+required-features = ["timechart"]
+
+[[example]]
+name = "timechart"
+required-features = ["timechart"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,11 @@ instant = { version = "0.1", features = ["wasm-bindgen"], optional = true }
 
 [dev-dependencies]
 eframe = "0.22.0"
+# Hacky way to enable features during testing
+egui-plotter = { path = ".", version = "0.3.0", features = ["timechart"]}
+
+[package.metadata.docs.rs]
+features = ["timechart"]
 
 [[example]]
 name = "spiral"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ as not only does it slow things down but it causes artifacts with certain plots.
 
 See line 24 example below to see how to disable feathering.
 
+### Features
+
+ * `timechart` - Includes all the pre-made animatable charts like XyTimeData and TimeData.
+
 ## Examples
 
 Here's a simple plotter example being run on native eframe.

--- a/src/charts/mod.rs
+++ b/src/charts/mod.rs
@@ -1,7 +1,11 @@
 //! Various type of premade charts.
 
+#[cfg(feature = "timechart")]
 mod timedata;
+#[cfg(feature = "timechart")]
 mod xytime;
 
+#[cfg(feature = "timechart")]
 pub use timedata::TimeData;
+#[cfg(feature = "timechart")]
 pub use xytime::XyTimeData;

--- a/src/charts/timedata.rs
+++ b/src/charts/timedata.rs
@@ -5,7 +5,7 @@ use plotters::style::{RGBAColor, ShapeStyle};
 
 use crate::charts::XyTimeData;
 
-/// Animatabe chart with time on the X axis and data on the Y axis.
+/// Animatable chart with time on the X axis and data on the Y axis.
 ///
 /// ## Usage
 /// **Ensure the `timechart` feature is enabled to use this type.**

--- a/src/charts/timedata.rs
+++ b/src/charts/timedata.rs
@@ -8,6 +8,7 @@ use crate::charts::XyTimeData;
 /// Animatabe chart with time on the X axis and data on the Y axis.
 ///
 /// ## Usage
+/// **Ensure the `timechart` feature is enabled to use this type.**
 ///
 /// Creating the chart is very simple. You only need to provide 4 parameters,
 /// 3 of which are just strings.

--- a/src/charts/xytime.rs
+++ b/src/charts/xytime.rs
@@ -1,13 +1,9 @@
 //! Animatable line chart. Can have X and Y points.
 
-use std::{
-    cmp::Ordering,
-    ops::Range,
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{cmp::Ordering, ops::Range, sync::Arc, time::Duration};
 
 use egui::Ui;
+use instant::Instant;
 use plotters::{
     prelude::ChartBuilder,
     series::LineSeries,

--- a/src/charts/xytime.rs
+++ b/src/charts/xytime.rs
@@ -54,6 +54,7 @@ struct XyTimeConfig {
 /// Animatable 2d line chart.
 ///
 /// ## Usage
+/// **Ensure the `timechart` feature is enabled to use this type.**
 ///
 /// Creating the chart is very simple. You only need to provide 4 parameters,
 /// 3 of which are just strings.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,8 +217,10 @@ pub use chart::{
     Chart, MouseButton, MouseConfig, Transform, DEFAULT_MOVE_SCALE, DEFAULT_SCROLL_SCALE,
 };
 
+#[cfg(feature = "timechart")]
 use std::ops::Range;
 
+#[cfg(feature = "timechart")]
 fn mult_range(range: Range<f32>, mult: f32) -> Range<f32> {
     let delta = range.end - range.start;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,10 @@
 //!
 //! See line 24 example below to see how to disable feathering.
 //!
+//! ### Features
+//!
+//!  * `timechart` - Includes all the pre-made animatable charts like XyTimeData and TimeData.
+//!
 //! ## Examples
 //!
 //! Here's a simple plotter example being run on native eframe.


### PR DESCRIPTION
just a pr for #2 which puts the timechart and timedata behind the timechart feature - more features can always be made for other charts in the future
also made the feature rely on the `instant` crate which works on wasm and actually doesn't add bloat on native because it falls back to the standard library