### PR TITLE
Update deps eframe and egui to v0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,14 @@ exclude = [
 timechart = ["dep:instant"]
 
 [dependencies]
-egui = "0.22" 
+egui = "0.23"
 plotters-backend = "0.3"
 plotters = "0.3"
 # if you are using egui then chances are you're using trunk which uses wasm bindgen
 instant = { version = "0.1", features = ["wasm-bindgen"], optional = true }
 
 [dev-dependencies]
-eframe = "0.22.0"
+eframe = "0.23.0"
 # Hacky way to enable features during testing
 egui-plotter = { path = ".", version = "0.3.0", features = ["timechart"]}
 


### PR DESCRIPTION
This is needed so that other repos that use egui-plotter don't end up with two versions of eframe and egui, v0.23 and v0.22. When that happens there can be an "error[E0308]: mismatched types. Such as when the first example in README.md is compiled.