### PR TITLE
Update deps eframe and egui to v0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,14 @@ exclude = [
 timechart = ["dep:instant"]
 
 [dependencies]
-egui = "0.22" 
+egui = "0.24"
 plotters-backend = "0.3"
 plotters = "0.3"
 # if you are using egui then chances are you're using trunk which uses wasm bindgen
 instant = { version = "0.1", features = ["wasm-bindgen"], optional = true }
 
 [dev-dependencies]
-eframe = "0.22.0"
+eframe = "0.24.0"
 # Hacky way to enable features during testing
 egui-plotter = { path = ".", version = "0.3.0", features = ["timechart"]}
 


### PR DESCRIPTION
Similar to the  [previous pull request](https://github.com/Gip-Gip/egui-plotter/pull/9).
Packages who use this repo as dependency has egui versions conflict "error[E0308]: mismatched types - two different versions of crate `egui` are being used".
