### PR TITLE
update deps egui and eframe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ Cargo.lock
 
 /target
 /Cargo.lock
+
+# Project dependend vscode-settings
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,16 +17,16 @@ exclude = [
 timechart = ["dep:instant"]
 
 [dependencies]
-egui = "0.22" 
+egui = "0.25" 
 plotters-backend = "0.3"
 plotters = "0.3"
 # if you are using egui then chances are you're using trunk which uses wasm bindgen
 instant = { version = "0.1", features = ["wasm-bindgen"], optional = true }
 
 [dev-dependencies]
-eframe = "0.22.0"
+eframe = "0.25.0"
 # Hacky way to enable features during testing
-egui-plotter = { path = ".", version = "0.3.0", features = ["timechart"]}
+egui-plotter = { path = ".", version = "0.3", features = ["timechart"]}
 
 [package.metadata.docs.rs]
 features = ["timechart"]

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -361,7 +361,7 @@ impl<'a> DrawingBackend for EguiBackend<'a> {
         if !galley.is_empty() {
             painter.add(TextShape {
                 angle,
-                ..TextShape::new(rect.min, galley)
+                ..TextShape::new(rect.min, galley, Color32::PLACEHOLDER)
             });
         }
 


### PR DESCRIPTION
Closes #12 

Similar to the two pull requests regarding the previous versions of egui 0.24 and 0.23.

epaint version 0.25 introduced a breaking change in `TextShape::new`, see the [Pull Request in egui](https://github.com/emilk/egui/pull/3727). Using the `Color::PLACEHOLDER` should be sufficient as argument here, since a colored galley is used (see line 359 in `src/backend.rs`) @Gip-Gip what do you think?

Code compiles and works within my wasm project (3D chart - thanks for this!!!) with rust version 1.75. I have not checked the native examples `egui-plotter/examples`.