### PR TITLE
Fix polygon drawing to allow feathering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,15 @@ exclude = [
 timechart = ["dep:instant"]
 
 [dependencies]
-egui = "0.25" 
+egui = "0.27.2"
 plotters-backend = "0.3"
 plotters = "0.3"
+earcutr = "0.4.3"
 # if you are using egui then chances are you're using trunk which uses wasm bindgen
 instant = { version = "0.1", features = ["wasm-bindgen"], optional = true }
 
 [dev-dependencies]
-eframe = "0.25.0"
+eframe = "0.27.2"
 # Hacky way to enable features during testing
 egui-plotter = { path = ".", version = "0.3", features = ["timechart"]}
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,6 @@ project's `Cargo.toml`.
 egui-plotter = "0.3.0"
 ```
 
-**It is also heavily recommended you disable feathering in your egui context,
-as not only does it slow things down but it causes artifacts with certain plots.**
-
-See line 24 example below to see how to disable feathering.
-
 ### Features
 
  * `timechart` - Includes all the pre-made animatable charts like XyTimeData and TimeData.
@@ -53,14 +48,8 @@ struct Simple;
 
 impl Simple {
     fn new(cc: &eframe::CreationContext<'_>) -> Self {
-        // Disable feathering as it causes artifacts
+        // Enable light mode
         let context = &cc.egui_ctx;
-
-        context.tessellation_options_mut(|tess_options| {
-            tess_options.feathering = false;
-        });
-
-        // Also enable light mode
         context.set_visuals(Visuals::light());
 
         Self
@@ -132,14 +121,8 @@ struct ParaChart {
 
 impl ParaChart {
     fn new(cc: &eframe::CreationContext<'_>) -> Self {
-        // Disable feathering as it causes artifacts
+        // Enable light mode
         let context = &cc.egui_ctx;
-
-        context.tessellation_options_mut(|tess_options| {
-            tess_options.feathering = false;
-        });
-
-        // Also enable light mode
         context.set_visuals(Visuals::light());
 
         // We use data to adjust the range of the chart. This can be useful for

--- a/examples/3d.rs
+++ b/examples/3d.rs
@@ -63,7 +63,7 @@ impl eframe::App for ThreeD {
                     false => (self.chart_pitch_vel, self.chart_yaw_vel),
                 };
 
-                let scale_delta = input.scroll_delta.y * SCROLL_SCALE;
+                let scale_delta = input.smooth_scroll_delta.y * SCROLL_SCALE;
 
                 (pitch_delta, yaw_delta, scale_delta)
             });

--- a/examples/3d.rs
+++ b/examples/3d.rs
@@ -30,14 +30,8 @@ struct ThreeD {
 
 impl ThreeD {
     fn new(cc: &eframe::CreationContext<'_>) -> Self {
-        // Disable feathering as it causes artifacts
+        // Enable light mode
         let context = &cc.egui_ctx;
-
-        context.tessellation_options_mut(|tess_options| {
-            tess_options.feathering = false;
-        });
-
-        // Also enable light mode
         context.set_visuals(Visuals::light());
 
         Self {

--- a/examples/3dchart.rs
+++ b/examples/3dchart.rs
@@ -24,14 +24,8 @@ struct Chart3d {
 
 impl Chart3d {
     fn new(cc: &eframe::CreationContext<'_>) -> Self {
-        // Disable feathring as it causes artifacts
+        // Enable light mode
         let context = &cc.egui_ctx;
-
-        context.tessellation_options_mut(|tess_options| {
-            tess_options.feathering = false;
-        });
-
-        // Also enable light mode
         context.set_visuals(Visuals::light());
 
         // Create a new 3d chart with all mouse controls enabled and the chart slightly angled

--- a/examples/parachart.rs
+++ b/examples/parachart.rs
@@ -23,14 +23,8 @@ struct ParaChart {
 
 impl ParaChart {
     fn new(cc: &eframe::CreationContext<'_>) -> Self {
-        // Disable feathering as it causes artifacts
+        // Enable light mode
         let context = &cc.egui_ctx;
-
-        context.tessellation_options_mut(|tess_options| {
-            tess_options.feathering = false;
-        });
-
-        // Also enable light mode
         context.set_visuals(Visuals::light());
 
         // We use data to adjust the range of the chart. This can be useful for

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -20,14 +20,8 @@ struct Simple;
 
 impl Simple {
     fn new(cc: &eframe::CreationContext<'_>) -> Self {
-        // Disable feathering as it causes artifacts
+        // Enable light mode
         let context = &cc.egui_ctx;
-
-        context.tessellation_options_mut(|tess_options| {
-            tess_options.feathering = false;
-        });
-
-        // Also enable light mode
         context.set_visuals(Visuals::light());
 
         Self

--- a/examples/spiral.rs
+++ b/examples/spiral.rs
@@ -29,14 +29,8 @@ struct SprialExample {
 
 impl SprialExample {
     fn new(cc: &eframe::CreationContext<'_>) -> Self {
-        // Disable feathering as it causes artifacts
+        // Enable dark mode
         let context = &cc.egui_ctx;
-
-        context.tessellation_options_mut(|tess_options| {
-            tess_options.feathering = false;
-        });
-
-        // Also enable light mode
         context.set_visuals(Visuals::dark());
 
         let mut points: Vec<(f32, f32, f32)> = Vec::with_capacity(SPIRAL_LEN * SPIRAL_SUB);

--- a/examples/timechart.rs
+++ b/examples/timechart.rs
@@ -25,14 +25,8 @@ struct TimeDataExample {
 
 impl TimeDataExample {
     fn new(cc: &eframe::CreationContext<'_>) -> Self {
-        // Disable feathering as it causes artifacts
+        // Enable light mode
         let context = &cc.egui_ctx;
-
-        context.tessellation_options_mut(|tess_options| {
-            tess_options.feathering = false;
-        });
-
-        // Also enable light mode
         context.set_visuals(Visuals::light());
 
         let mut points: Vec<(f32, f32)> = Vec::with_capacity(DISTANCE_M.len());

--- a/src/chart.rs
+++ b/src/chart.rs
@@ -354,7 +354,7 @@ impl<Data> Chart<Data> {
 
             // Adjust zoom if zoom is enabled
             if self.mouse.zoom {
-                let scale_delta = input.scroll_delta.y * self.mouse.zoom_scale;
+                let scale_delta = input.smooth_scroll_delta.y * self.mouse.zoom_scale;
 
                 // !TODO! make scaling exponential
                 transform.scale = (transform.scale + scale_delta as f64).abs();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,11 +17,6 @@
 //! egui-plotter = "0.3.0"
 //! ```
 //!
-//! **It is also heavily recommended you disable feathering in your egui context,
-//! as not only does it slow things down but it causes artifacts with certain plots.**
-//!
-//! See line 24 example below to see how to disable feathering.
-//!
 //! ### Features
 //!
 //!  * `timechart` - Includes all the pre-made animatable charts like XyTimeData and TimeData.
@@ -52,14 +47,8 @@
 //!
 //! impl Simple {
 //!     fn new(cc: &eframe::CreationContext<'_>) -> Self {
-//!         // Disable feathering as it causes artifacts
+//!         // Enable light mode
 //!         let context = &cc.egui_ctx;
-//!
-//!         context.tessellation_options_mut(|tess_options| {
-//!             tess_options.feathering = false;
-//!         });
-//!
-//!         // Also enable light mode
 //!         context.set_visuals(Visuals::light());
 //!
 //!         Self
@@ -131,14 +120,8 @@
 //!
 //! impl ParaChart {
 //!     fn new(cc: &eframe::CreationContext<'_>) -> Self {
-//!         // Disable feathering as it causes artifacts
+//!         // Enable light mode
 //!         let context = &cc.egui_ctx;
-//!
-//!         context.tessellation_options_mut(|tess_options| {
-//!             tess_options.feathering = false;
-//!         });
-//!
-//!         // Also enable light mode
 //!         context.set_visuals(Visuals::light());
 //!
 //!         // We use data to adjust the range of the chart. This can be useful for


### PR DESCRIPTION
This PR makes a change to the polygon drawing function in order to support non-convex polygons. Non-convex polygons caused glitches when feathering was enabled.

The polygons are now drawn by first triangulating it (with a function from the [earcutr](https://docs.rs/earcutr/latest/earcutr/) crate) and then creating a `Mesh` from the resulting set of triangles.

Feathering can now be enabled and the plots look much nicer:

Before:

<img width="475" alt="Screenshot 2024-05-27 at 09 53 00" src="https://github.com/Gip-Gip/egui-plotter/assets/3522732/1cdd9d46-66a9-4af9-90f1-449fd8228db3">

After:

<img width="514" alt="Screenshot 2024-05-27 at 09 51 35" src="https://github.com/Gip-Gip/egui-plotter/assets/3522732/f571de9c-9ac4-43d2-97ac-18cc4f9c628b">

The downside is the additional dependency, but I'm not aware of how to support non-convex polygons in another way.

This PR also bumps egui to 0.27.2.