### PR TITLE
upgrade egui -> 0.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 timechart = ["dep:instant"]
 
 [dependencies]
-egui = "0.25" 
+egui = "0.30" 
 plotters-backend = "0.3"
 plotters = "0.3"
 # if you are using egui then chances are you're using trunk which uses wasm bindgen

--- a/src/chart.rs
+++ b/src/chart.rs
@@ -354,7 +354,7 @@ impl<Data> Chart<Data> {
 
             // Adjust zoom if zoom is enabled
             if self.mouse.zoom {
-                let scale_delta = input.scroll_delta.y * self.mouse.zoom_scale;
+                let scale_delta = input.raw_scroll_delta.y * self.mouse.zoom_scale;
 
                 // !TODO! make scaling exponential
                 transform.scale = (transform.scale + scale_delta as f64).abs();


### PR DESCRIPTION
***

### Fix issue  #21 

***

### Why? 

I wanted to develop my project to support both a desktop application and a web application.
I need to use egui 0.30 in order to support this, also egui is now the latest version.

So I figured I could contribute with this small change :wink: 

***