### PR TITLE
Update egui and eframe dependencies to version 0.32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,14 @@ exclude = ["images"]
 timechart = ["dep:instant"]
 
 [dependencies]
-egui = "0.31"
+egui = "0.32"
 plotters-backend = "0.3"
 plotters = "0.3"
 # if you are using egui then chances are you're using trunk which uses wasm bindgen
 instant = { version = "0.1", features = ["wasm-bindgen"], optional = true }
 
 [dev-dependencies]
-eframe = "0.31"
+eframe = "0.32"
 # Hacky way to enable features during testing
 egui-plotter = { path = ".", features = ["timechart"] }
 


### PR DESCRIPTION
In this PR i just bumped the version of `eframe` and `egui` from `0.31` to `0.32`.
All tests and examples are  still working.