### PR TITLE
Relax egui version requirements to support 0.32.1 through 0.34

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,10 @@ earcutr = "0.4.3"
 instant = { version = "0.1", features = ["wasm-bindgen"], optional = true }
 
 [dev-dependencies]
-eframe = "0.32.1"
+eframe = "0.34"
 # Hacky way to enable features during testing
 egui-plotter = { path = ".", features = ["timechart"] }
-egui_extras = { version = "0.32.1", features = ["all_loaders"] }
+egui_extras = { version = "0.34", features = ["all_loaders"] }
 image = { version = "0.25", features = ["png"] } # Add the types you want support for
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["images"]
 timechart = ["dep:instant"]
 
 [dependencies]
-egui = "0.32.1"
+egui = ">=0.32.1, <0.35"
 plotters-backend = "0.3"
 plotters = "0.3"
 earcutr = "0.4.3"

--- a/examples/3d.rs
+++ b/examples/3d.rs
@@ -45,8 +45,9 @@ impl ThreeD {
 }
 
 impl eframe::App for ThreeD {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        CentralPanel::default().show(ctx, |ui| {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        let ctx = ui.ctx().clone();
+        CentralPanel::default().show_inside(ui, |ui| {
             // First, get mouse data
             let (pitch_delta, yaw_delta, scale_delta) = ui.input(|input| {
                 let pointer = &input.pointer;

--- a/examples/3dchart.rs
+++ b/examples/3dchart.rs
@@ -97,8 +97,9 @@ impl Chart3d {
 }
 
 impl eframe::App for Chart3d {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        CentralPanel::default().show(ctx, |ui| {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        let ctx = ui.ctx().clone();
+        CentralPanel::default().show_inside(ui, |ui| {
             self.chart.draw(ui);
         });
 

--- a/examples/parachart.rs
+++ b/examples/parachart.rs
@@ -73,8 +73,8 @@ impl ParaChart {
 }
 
 impl eframe::App for ParaChart {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        CentralPanel::default().show(ctx, |ui| {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        CentralPanel::default().show_inside(ui, |ui| {
             // Press 1 for the range -1..1, 2 for -2..2, 3 for -3..3
             ui.input(|input| {
                 if input.key_down(Key::Num1) {

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -29,8 +29,8 @@ impl Simple {
 }
 
 impl eframe::App for Simple {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        CentralPanel::default().show(ctx, |ui| {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        CentralPanel::default().show_inside(ui, |ui| {
             let plotter_canvas = PlotterCanvas::with_cb(|ui| {
                 let root = EguiBackend::new(ui).into_drawing_area();
                 root.fill(&WHITE).unwrap();

--- a/examples/simple_bg.rs
+++ b/examples/simple_bg.rs
@@ -39,11 +39,11 @@ impl SimpleBGImage {
 }
 
 impl eframe::App for SimpleBGImage {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
 
         if self.bg_image_id.is_none() {
             // Sizehint doesn't affect bitmap textures(png, jpeg, gif, etc.)
-            let bg_image_result = ctx.try_load_texture("file://images/bg_test.png", TextureOptions::NEAREST, SizeHint::Width(4000));
+            let bg_image_result = ui.ctx().try_load_texture("file://images/bg_test.png", TextureOptions::NEAREST, SizeHint::Width(4000));
 
 
             if let Some(id) = bg_image_result.unwrap().texture_id() {
@@ -52,7 +52,7 @@ impl eframe::App for SimpleBGImage {
 
         }
 
-        CentralPanel::default().show(ctx, |ui| {
+        CentralPanel::default().show_inside(ui, |ui| {
             let root = match self.bg_image_id {
                 Some(bg_image_id) => EguiBackend::new(ui).bg_image(bg_image_id, BgImageSize::Fit),
                 None => EguiBackend::new(ui),

--- a/examples/spiral.rs
+++ b/examples/spiral.rs
@@ -77,8 +77,9 @@ impl SprialExample {
 }
 
 impl eframe::App for SprialExample {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        TopBottomPanel::bottom("playmenu").show(ctx, |ui| {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        let ctx = ui.ctx().clone();
+        TopBottomPanel::bottom("playmenu").show_inside(ui, |ui| {
             ui.horizontal(|ui| {
                 match self.spiralchart.is_playing() {
                     true => {
@@ -117,7 +118,7 @@ impl eframe::App for SprialExample {
             })
         });
 
-        CentralPanel::default().show(ctx, |ui| {
+        CentralPanel::default().show_inside(ui, |ui| {
             self.spiralchart.draw(ui);
         });
 

--- a/examples/timechart.rs
+++ b/examples/timechart.rs
@@ -42,8 +42,9 @@ impl TimeDataExample {
 }
 
 impl eframe::App for TimeDataExample {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        TopBottomPanel::bottom("playmenu").show(ctx, |ui| {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        let ctx = ui.ctx().clone();
+        TopBottomPanel::bottom("playmenu").show_inside(ui, |ui| {
             ui.horizontal(|ui| {
                 match self.timechart.is_playing() {
                     true => {
@@ -82,7 +83,7 @@ impl eframe::App for TimeDataExample {
             })
         });
 
-        CentralPanel::default().show(ctx, |ui| {
+        CentralPanel::default().show_inside(ui, |ui| {
             self.timechart.draw(ui);
         });
 


### PR DESCRIPTION
## Summary

Relax the `egui` version requirements from `0.32.1` to `>=0.32.1,<0.35`.

I confirmed that the current `egui-plotter` library is compatible with `egui` 0.33 and 0.34. The examples have also been updated for `egui` 0.34.

## Testing

Examples were tested with `egui` 0.34 on:
- Windows
- Linux (Ubuntu)